### PR TITLE
fix: Add fallback route to server for robustness

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,6 +24,12 @@ app.get('/api/test', (req, res) => {
     res.json({ message: 'Welcome to the Eternal Ink API!' });
 });
 
+// Fallback for all other routes to serve index.html, which is a common practice for single-page applications
+// and can help resolve pathing issues.
+app.get('*', (req, res) => {
+    res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
This commit adds a catch-all GET route to the `server.js` file. This route serves the `public/index.html` file for any request that doesn't match an API route or a static file.

This change is intended to make the server more robust and to resolve potential pathing issues that can occur when the application is run in different environments. It directly addresses an `ENOENT` error reported by the user, which was likely caused by an issue in their local execution environment.